### PR TITLE
feature: Highlight Color command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,15 @@ Update Background
 ### 1.2.0 February 28th 2021
 
 Fixed highlights not being updated when adding text to the document
+
+### 1.2.1
+
+Updated packages.
+
+### 1.3.1
+
+Fixed issue where duplicate highlight applied to the same range would not be able to be removed. Duplicate highlight does not happen on the same range, but will not cause issue when trying to remove highlight.
+
+### 1.4.0
+
+Added Highlight Color command.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Updated packages.
 
 Fixed issue where duplicate highlight applied to the same range would not be able to be removed. Duplicate highlight does not happen on the same range, but will not cause issue when trying to remove highlight.
 
+### 1.4.0
+
+Added Highlight Color command.
+
 ## Known Issues:
 - Selecting a single character and typing a single character reduces highlight range.
 - Newlines added or removed within highlight range causes unexpected behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
 	"name": "easy-highlight",
-	"version": "1.2.0",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "easy-highlight",
-			"version": "1.2.0",
+			"version": "1.4.0",
+			"license": "MIT",
 			"dependencies": {
 				"@types/validator": "^13.0.0",
 				"validator": "^13.15.26"
@@ -172,6 +173,7 @@
 			"integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-visitor-keys": "^1.0.0",
 				"@typescript-eslint/experimental-utils": "2.34.0",
@@ -240,6 +242,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
 			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -737,6 +740,7 @@
 			"integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"ajv": "^6.10.0",
@@ -2644,6 +2648,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
 			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "easy-highlight",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"type": "git",
 		"url": "https://github.com/BrandonBlaschke/vscode-easy-highlight"
 	},
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"author": {
 		"name": "Brandon Blaschke"
 	},
@@ -43,6 +43,10 @@
 			{
 				"command": "easy-highlight.Highlight",
 				"title": "Highlight"
+			},
+			{
+				"command": "easy-highlight.HighlightColor",
+				"title": "Highlight Color"
 			},
 			{
 				"command": "easy-highlight.RemoveHighlight",


### PR DESCRIPTION
Added **additional command** called `Highlight Color`. When selected, it will prompt you with a selection of which color you want to use; when the color is selected, it will highlight that code with that color.

The normal `Highlight` command is unaffected to this.

<img width="608" height="127" alt="image" src="https://github.com/user-attachments/assets/f3c02f46-0b70-4f6a-a600-def1ad8a8d1b" />

<img width="1249" height="1358" alt="image" src="https://github.com/user-attachments/assets/175885d0-a13e-4a1c-bc41-c58509752e1f" />
